### PR TITLE
add logic to download correct system build of `dart-sass`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
-  - repo: https://github.com/ambv/black
-    rev: 22.1.0
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
     - id: black
+      additional_dependencies: ['click==8.1.2']
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-      additional_dependencies: ['click==8.1.2']
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You'll need to be relatively familiar with HTML and (S)CSS to make best use of M
 pip install mkposters
 ```
 
+On initial run of `mkposters`, a post-install script, `post_install.py`, will attempt to automatically detect system architecture and install the appropriate required build of `dart-sass`. This was tested working on both an Apple M1 and Ubuntu x86_64 machine.
+
 ## Usage instructions
 
 1. Create the appropriate directory structure

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -6,6 +6,8 @@ import tempfile
 
 import markdown
 
+from .post_install import main as post_install
+
 
 _here = pathlib.Path(__file__).resolve().parent
 
@@ -61,6 +63,10 @@ def mkposter(datadir):
         </body>
         </html>
         """  # noqa: E501
+
+        # check if post-install of dart-sass is needed
+        if not (_here / "third_party" / "dart-sass" / "SASSBUILT.txt").exists():
+            post_install()
 
         subprocess.run(
             [

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -6,7 +6,7 @@ import tempfile
 
 import markdown
 
-from .post_install import main as post_install
+from .post_install import post_install
 
 
 _here = pathlib.Path(__file__).resolve().parent
@@ -66,7 +66,7 @@ def mkposter(datadir):
 
         # check if post-install of dart-sass is needed
         if not (_here / "third_party" / "dart-sass" / "SASSBUILT.txt").exists():
-            post_install()
+            post_install(package_dir=str(_here))
 
         subprocess.run(
             [

--- a/mkposters/post_install.py
+++ b/mkposters/post_install.py
@@ -1,0 +1,53 @@
+import subprocess
+
+
+def main():
+    bash_cmd = """
+    # Detect the compute architecture (linux-arm64, macos-arm64, macos-x64) and download the appropriate distribution release of dart-sass
+    # https://github.com/sass/dart-sass/releases/tag/1.50.1
+
+    sass_release="1.50.1"
+    arch=$(uname -m)
+    kernel=$(uname -s)
+
+    echo Detected architecture: $arch and kernel: $kernel.
+
+    if [[ "$arch" =~ ^(arm64|aarch64)$ ]] && [ "$kernel" = "Linux" ]; then
+        curl -sL "https://github.com/sass/dart-sass/releases/download/${sass_release}/dart-sass-${sass_release}-linux-arm64.tar.gz" > dart.tar.gz && tar -xzf dart.tar.gz && rm dart.tar.gz
+    elif [ "$arch" = "x86_64" ] && [ "$kernel" = "Linux" ]; then
+        curl -sL "https://github.com/sass/dart-sass/releases/download/${sass_release}/dart-sass-${sass_release}-linux-x64.tar.gz" > dart.tar.gz && tar -xzf dart.tar.gz && rm dart.tar.gz
+    elif [ "$arch" = "arm64" ] && [ "$kernel" = "Darwin" ]; then
+        curl -sL "https://github.com/sass/dart-sass/releases/download/${sass_release}/dart-sass-${sass_release}-macos-arm64.tar.gz" > dart.tar.gz && tar -xzf dart.tar.gz && rm dart.tar.gz
+    elif [ "$arch" = "x86_64" ] && [ "$kernel" = "Darwin" ]; then
+        curl -sL "https://github.com/sass/dart-sass/releases/download/${sass_release}/dart-sass-${sass_release}-macos-x64.tar.gz" > dart.tar.gz && tar -xzf dart.tar.gz && rm dart.tar.gz
+    else
+        echo "Unsupported architecture: $arch and kernel: $kernel"
+    fi
+
+    # move the dart-sass binary to the correct location
+    mkloc=$(pip show mkposters | grep Location | cut -d ' ' -f 2)
+    rm -rf $mkloc/mkposters/third_party/dart-sass && mv dart-sass $mkloc/mkposters/third_party
+    echo "Downloaded from https://github.com/sass/dart-sass/releases/download/${sass_release} \nSee also:\nhttps://sass-lang.com/install\ninstalled version: ${sass_release}" > "${mkloc}/mkposters/third_party/dart-sass/SASSBUILT.txt"
+    """  # noqa: E501
+
+    with subprocess.Popen(
+        bash_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+        close_fds=True,
+        shell=True,
+        executable="/bin/bash",
+    ) as proc:
+        if proc.stdout:
+            with proc.stdout:
+                for line in iter(proc.stdout.readline, b""):
+                    print(line.decode().rstrip())
+
+        exit_code = proc.wait()
+        if exit_code != 0:
+            raise Exception(f"post_install.py failed with exit code {exit_code}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkposters/post_install.py
+++ b/mkposters/post_install.py
@@ -1,33 +1,52 @@
+import pathlib
 import subprocess
 
 
-def main():
-    bash_cmd = """
+def post_install(package_dir: str, sass_release: str = "1.50.1"):
+    """
+    Run post-install of dart-sass.
+    Detect the compute architecture (linux-arm64, linux-x64, macos-arm64, macos-x64) and download the appropriate distribution release of dart-sass.
+    See also: https://github.com/sass/dart-sass/releases
+
+    Args:
+        package_dir (str): The location of `mkposters`. This is the directory that contains the `third_party` folder which dart-sass should be installed in.
+        sass_release (str): The release version of sass to download.
+    Returns:
+        None
+
+    """  # noqa: E501
+
+    sass_dir = pathlib.Path(package_dir) / "third_party"
+
+    bash_cmd = f"""
     # Detect the compute architecture (linux-arm64, macos-arm64, macos-x64) and download the appropriate distribution release of dart-sass
     # https://github.com/sass/dart-sass/releases/tag/1.50.1
 
-    sass_release="1.50.1"
     arch=$(uname -m)
     kernel=$(uname -s)
 
     echo Detected architecture: $arch and kernel: $kernel.
 
     if [[ "$arch" =~ ^(arm64|aarch64)$ ]] && [ "$kernel" = "Linux" ]; then
-        curl -sL "https://github.com/sass/dart-sass/releases/download/${sass_release}/dart-sass-${sass_release}-linux-arm64.tar.gz" > dart.tar.gz && tar -xzf dart.tar.gz && rm dart.tar.gz
+        curl -sL "https://github.com/sass/dart-sass/releases/download/{sass_release}/dart-sass-{sass_release}-linux-arm64.tar.gz" > {sass_dir}/dart.tar.gz && tar -xzf {sass_dir}/dart.tar.gz --directory {sass_dir} && rm {sass_dir}/dart.tar.gz && chmod 755 {sass_dir}/dart-sass/sass
+        echo "Downloaded https://github.com/sass/dart-sass/releases/download/{sass_release}/dart-sass-{sass_release}-linux-arm64.tar.gz \nSee also:\nhttps://sass-lang.com/install\ninstalled version: {sass_release}" > "{sass_dir}/dart-sass/SASSBUILT.txt"
+
     elif [ "$arch" = "x86_64" ] && [ "$kernel" = "Linux" ]; then
-        curl -sL "https://github.com/sass/dart-sass/releases/download/${sass_release}/dart-sass-${sass_release}-linux-x64.tar.gz" > dart.tar.gz && tar -xzf dart.tar.gz && rm dart.tar.gz
+        curl -sL "https://github.com/sass/dart-sass/releases/download/{sass_release}/dart-sass-{sass_release}-linux-x64.tar.gz" > {sass_dir}/dart.tar.gz && tar -xzf {sass_dir}/dart.tar.gz --directory {sass_dir} && rm {sass_dir}/dart.tar.gz && chmod 755 {sass_dir}/dart-sass/sass
+        echo "Downloaded https://github.com/sass/dart-sass/releases/download/{sass_release}/dart-sass-{sass_release}-linux-x64.tar.gz \nSee also:\nhttps://sass-lang.com/install\ninstalled version: {sass_release}" > "{sass_dir}/dart-sass/SASSBUILT.txt"
+
     elif [ "$arch" = "arm64" ] && [ "$kernel" = "Darwin" ]; then
-        curl -sL "https://github.com/sass/dart-sass/releases/download/${sass_release}/dart-sass-${sass_release}-macos-arm64.tar.gz" > dart.tar.gz && tar -xzf dart.tar.gz && rm dart.tar.gz
+        curl -sL "https://github.com/sass/dart-sass/releases/download/{sass_release}/dart-sass-{sass_release}-macos-arm64.tar.gz" > {sass_dir}/dart.tar.gz && tar -xzf {sass_dir}/dart.tar.gz --directory {sass_dir} && rm {sass_dir}/dart.tar.gz && chmod 755 {sass_dir}/dart-sass/sass
+        echo "Downloaded https://github.com/sass/dart-sass/releases/download/{sass_release}/dart-sass-{sass_release}-macos-arm64.tar.gz \nSee also:\nhttps://sass-lang.com/install\ninstalled version: {sass_release}" > "{sass_dir}/dart-sass/SASSBUILT.txt"
+
     elif [ "$arch" = "x86_64" ] && [ "$kernel" = "Darwin" ]; then
-        curl -sL "https://github.com/sass/dart-sass/releases/download/${sass_release}/dart-sass-${sass_release}-macos-x64.tar.gz" > dart.tar.gz && tar -xzf dart.tar.gz && rm dart.tar.gz
+        curl -sL "https://github.com/sass/dart-sass/releases/download/{sass_release}/dart-sass-{sass_release}-macos-x64.tar.gz" > {sass_dir}/dart.tar.gz && tar -xzf {sass_dir}/dart.tar.gz --directory {sass_dir} && rm {sass_dir}/dart.tar.gz && chmod 755 {sass_dir}/dart-sass/sass
+        echo "Downloaded https://github.com/sass/dart-sass/releases/download/{sass_release}/dart-sass-{sass_release}-macos-x64.tar.gz \nSee also:\nhttps://sass-lang.com/install\ninstalled version: {sass_release}" > "{sass_dir}/dart-sass/SASSBUILT.txt"
+
     else
         echo "Unsupported architecture: $arch and kernel: $kernel"
     fi
 
-    # move the dart-sass binary to the correct location
-    mkloc=$(pip show mkposters | grep Location | cut -d ' ' -f 2)
-    rm -rf $mkloc/mkposters/third_party/dart-sass && mv dart-sass $mkloc/mkposters/third_party
-    echo "Downloaded from https://github.com/sass/dart-sass/releases/download/${sass_release} \nSee also:\nhttps://sass-lang.com/install\ninstalled version: ${sass_release}" > "${mkloc}/mkposters/third_party/dart-sass/SASSBUILT.txt"
     """  # noqa: E501
 
     with subprocess.Popen(
@@ -50,4 +69,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    post_install()


### PR DESCRIPTION
On running `mkposter` for the first time, this PR adds logic to detect system architecture and download the appropriate system build of `dart-sass`. Tested on Apple M1 and Ubuntu x86_64.