### PR TITLE
Adds `mermaid.js` and `highlight.js` for code formatting along with `Fire` managed args to mkposter

### DIFF
--- a/mkposters/__main__.py
+++ b/mkposters/__main__.py
@@ -1,7 +1,7 @@
-import sys
+import fire
 
 from .mkposter import mkposter
 
 
-_, filename = sys.argv
-mkposter(filename)
+if __name__ == "__main__":
+    fire.Fire(mkposter)

--- a/mkposters/custom.scss
+++ b/mkposters/custom.scss
@@ -47,7 +47,3 @@ hr {
 .md-typeset ul li {
     margin-bottom: 0;
 }
-
-body {
-    background-color: #F6F6EF;
-}

--- a/mkposters/custom.scss
+++ b/mkposters/custom.scss
@@ -47,3 +47,7 @@ hr {
 .md-typeset ul li {
     margin-bottom: 0;
 }
+
+body {
+    background-color: #F6F6EF;
+}

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -42,6 +42,10 @@ def mkposter(
         port (int): The port to use for the server.
     Returns:
         Rendered markdown as HTML via `http.server` on specified port.
+    Example:
+        ```bash
+        python -m mkposters "research_app/poster" --code_style "github" --background_color "#F6F6EF" --port 8000
+        ```
     """
 
     with tempfile.TemporaryDirectory() as tempdir:

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -19,7 +19,7 @@ def md_to_html(md):
     )
 
 
-def mkposter(datadir):
+def mkposter(datadir, code_style="github"):
     with tempfile.TemporaryDirectory() as tempdir:
         tempdir = pathlib.Path(tempdir)
         datadir = pathlib.Path(datadir)
@@ -44,6 +44,9 @@ def mkposter(datadir):
         <head>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700%7CRoboto+Mono&amp;display=fallback">
         <link rel="stylesheet" type="text/css" href="style.css"/>
+        <link href='//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css' rel='stylesheet'/>
+        <script src='//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js'/>
+        <script>hljs.initHighlightingOnLoad();</script>
         <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
         <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
         </head>

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -46,7 +46,7 @@ def mkposter(
         ```bash
         python -m mkposters "research_app/poster" --code_style "github" --background_color "#F6F6EF" --port 8000
         ```
-    """
+    """  # noqa: E501
 
     with tempfile.TemporaryDirectory() as tempdir:
         tempdir = pathlib.Path(tempdir)

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -75,7 +75,7 @@ def mkposter(
         <link rel="stylesheet" type="text/css" href="style.css"/>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
+        <script>hljs.highlightAll();</script>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.css">
         <script src="https://unpkg.com/mermaid@9.0.1/dist/mermaid.min.js"></script>
         <script>mermaid.initialize();</script>

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -27,7 +27,7 @@ def md_to_html(md):
     )
 
 
-def mkposter(datadir, code_style="github"):
+def mkposter(datadir, code_style="github", background_color="#F6F6EF"):
     with tempfile.TemporaryDirectory() as tempdir:
         tempdir = pathlib.Path(tempdir)
         datadir = pathlib.Path(datadir)
@@ -50,6 +50,7 @@ def mkposter(datadir, code_style="github"):
         html_out = rf"""<!doctype html>
         <html>
         <head>
+        <body style="background-color:{background_color}">
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700%7CRoboto+Mono&amp;display=fallback">
         <link rel="stylesheet" type="text/css" href="style.css"/>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css">

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 
 import markdown
+from pymdownx.superfences import fence_div_format
 
 from .post_install import post_install
 
@@ -16,6 +17,13 @@ def md_to_html(md):
     return markdown.markdown(
         md,
         extensions=["admonition", "pymdownx.superfences", "smarty"],
+        extension_configs={
+            "pymdownx.superfences": {
+                "custom_fences": [
+                    {"name": "mermaid", "class": "mermaid", "format": fence_div_format}
+                ]
+            }
+        },
     )
 
 
@@ -47,6 +55,9 @@ def mkposter(datadir, code_style="github"):
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
         <script>hljs.initHighlightingOnLoad();</script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.css">
+        <script src="https://unpkg.com/mermaid@9.0.1/dist/mermaid.min.js"></script>
+        <script>mermaid.initialize();</script>
         <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
         <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
         </head>

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -68,7 +68,7 @@ def mkposter(
         banner, left_body, right_body = contents.split("--split--")
 
         custom_html = []
-        if code_style:
+        if code_style is not None:
             custom_html += [
                 f"""<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css">"""  # noqa: E501
             ]

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -27,7 +27,23 @@ def md_to_html(md):
     )
 
 
-def mkposter(datadir, code_style="github", background_color="#F6F6EF"):
+def mkposter(
+    datadir: str,
+    code_style: str = "github",
+    background_color: str = "#FFFFFF",
+    port: int = 8000,
+):
+    """
+    Make a poster from a Markdown file.
+    Args:
+        datadir (str): The directory containing the Markdown file.
+        code_style (str): The style of code blocks.
+        background_color (str): The background color of the poster.
+        port (int): The port to use for the server.
+    Returns:
+        Rendered markdown as HTML via `http.server` on specified port.
+    """
+
     with tempfile.TemporaryDirectory() as tempdir:
         tempdir = pathlib.Path(tempdir)
         datadir = pathlib.Path(datadir)
@@ -108,4 +124,5 @@ def mkposter(datadir, code_style="github", background_color="#F6F6EF"):
         with html_file.open("w") as f:
             f.write(html_out)
 
-        subprocess.run(["python", "-m", "http.server"], cwd=tempdir)
+        serve_cmd = f"python -m http.server {port}"
+        subprocess.run(serve_cmd.split(" "), cwd=tempdir)

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -44,8 +44,8 @@ def mkposter(datadir, code_style="github"):
         <head>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700%7CRoboto+Mono&amp;display=fallback">
         <link rel="stylesheet" type="text/css" href="style.css"/>
-        <link href='//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css' rel='stylesheet'/>
-        <script src='//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js'/>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
         <script>hljs.initHighlightingOnLoad();</script>
         <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
         <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -30,7 +30,6 @@ def md_to_html(md):
 def mkposter(
     datadir: str,
     code_style: str = "github",
-    background_color: str = "#FFFFFF",
     port: int = 8000,
 ):
     """
@@ -38,13 +37,12 @@ def mkposter(
     Args:
         datadir (str): The directory containing the Markdown file.
         code_style (str): The style of code blocks.
-        background_color (str): The background color of the poster.
         port (int): The port to use for the server.
     Returns:
         Rendered markdown as HTML via `http.server` on specified port.
     Example:
         ```bash
-        python -m mkposters "research_app/poster" --code_style "github" --background_color "#F6F6EF" --port 8000
+        python -m mkposters "research_app/poster" --code_style "github" --port 8000
         ```
     """  # noqa: E501
 
@@ -70,7 +68,6 @@ def mkposter(
         html_out = rf"""<!doctype html>
         <html>
         <head>
-        <body style="background-color:{background_color}">
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700%7CRoboto+Mono&amp;display=fallback">
         <link rel="stylesheet" type="text/css" href="style.css"/>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/{code_style}.min.css">

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -3,7 +3,7 @@ import re
 import shutil
 import subprocess
 import tempfile
-from typing import Optional, Union
+from typing import Optional
 
 import markdown
 from pymdownx.superfences import fence_div_format
@@ -32,7 +32,6 @@ def mkposter(
     datadir: str,
     code_style: Optional[str] = None,
     mermaid: Optional[bool] = False,
-    scss: Optional[Union[str, pathlib.Path]] = None,
     port: Optional[int] = 8000,
 ):
     """
@@ -41,7 +40,6 @@ def mkposter(
         datadir (str): The directory containing the Markdown file.
         code_style (Optional[str]): Defaults to using `pymdownx.superfences` implementation. Otherwise, choose a style supported by `highlight.js` (e.g. 'vs', 'github', 'atom-one-dark', etc.).
         mermaid (Optional[bool]): Whether to use the `mermaid` plugin to support rendering mermaid fenced code blocks.
-        scss (Optional[Union[str, pathlib.Path]]): The SCSS styling file to use. Defaults to included `style.scss`.
         port (Optional[int]): The port to use for the server.
     Returns:
         Rendered markdown as HTML via `http.server` on specified port.
@@ -121,14 +119,10 @@ def mkposter(
         if not (_here / "third_party" / "dart-sass" / "SASSBUILT.txt").exists():
             post_install(package_dir=str(_here))
 
-        style_sheet = f"{_here}/style.scss"
-        if scss:
-            style_sheet = scss
-
         subprocess.run(
             [
                 f"{_here}/third_party/dart-sass/sass",
-                style_sheet,
+                f"{_here}/style.scss",
                 str(css_file),
                 "--no-source-map",
             ]

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ classifiers = [
 
 python_requires = "~=3.7"
 
-install_requires = ["markdown>=3.3.6", "pymdown-extensions>=9.1"]
+install_requires = ["markdown>=3.3.6", "pymdown-extensions>=9.1", "fire>=0.4.0"]
 
 setuptools.setup(
     name=name,


### PR DESCRIPTION
Adds:
- `mermaid.js` diagram support for rendering mermaid blocks
- code rendering with `highlight.js`, default github theme
- pass arguments to mkposter using `Fire`
    - adds `background_color` str argument with default `#FFFFFF`
    - adds `code_style` str arg for `highlight.js` themes with default 'github'
    - adds `port` int arg to specify `http.server` port, with 8000 as default.

Example:
```bash
python -m mkposters "research_app/poster" --code_style "github" --background_color "#F6F6EF" --port 8000
```