### PR TITLE
add variable coll support

### DIFF
--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -34,12 +34,12 @@ def mkposter(datadir):
 
         with md_file.open() as f:
             contents = f.read()
-        banner, left_body, right_body = contents.split("--split--")
+        bodies = contents.split("--split--")
 
-        banner = md_to_html(banner)
-        left_body = md_to_html(left_body)
-        right_body = md_to_html(right_body)
-        html_out = rf"""<!doctype html>
+        bodies = [md_to_html(b) for b in bodies]
+        banner = bodies[0]
+
+        html_out = "\n".join([f"""<!doctype html>
         <html>
         <head>
         <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
@@ -53,17 +53,13 @@ def mkposter(datadir):
         {banner}
         </div>
         <hr>
-        <div class="body md-typeset">
-        <div class="left">
-        {left_body}
-        </div>
-        <div class="right">
-        {right_body}
-        </div>
+        <div class="body md-typeset">""",
+        "\n".join([f"<div class=\"Coll{i}\">\n{body}\n</div>" for i, body in enumerate(bodies[1:])]),
+        """
         </div>
         </body>
         </html>
-        """  # noqa: E501
+        """])  # noqa: E501
 
         # check if post-install of dart-sass is needed
         if not (_here / "third_party" / "dart-sass" / "SASSBUILT.txt").exists():


### PR DESCRIPTION
Split on an arbitrary number of --split-- tags and build the HTML based on however many colls are found in the markdown. This should maintain backwards compatibility except for the div names.