### PR TITLE
V003

### DIFF
--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -21,7 +21,7 @@ def md_to_html(md: str):
     )
 
 
-def excludeHiddenDirs(path, subdirs):
+def exclude_hidden_dirs(path, subdirs):
     return [p for p in subdirs if p.startswith(".")]
 
 def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.Path):
@@ -29,7 +29,7 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
         raise ValueError
     if (datadir / "stylesheets").exists():
         raise ValueError
-    shutil.copytree(datadir, tempdir, dirs_exist_ok=True, ignore=excludeHiddenDirs)
+    shutil.copytree(datadir, tempdir, dirs_exist_ok=True, ignore=exclude_hidden_dirs)
 
     md_file = tempdir / "poster.md"
     html_file = tempdir / "index.html"
@@ -41,7 +41,7 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
 
     bodies = [md_to_html(b) for b in bodies]
     banner = bodies[0]
-    left_body = bodies[1]# Still capture left and right seperatly for backwards compadibility
+    left_body = bodies[1]  # Still capture left and right separately for backwards compatibility
     right_body = bodies[-1]
     
     html_out = "\n".join([rf"""<!doctype html>
@@ -63,7 +63,7 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
     <div class="left">
     {left_body}
     </div>""", 
-    *[f"<div class=\"Middle_{i}\">\n{body}\n</div>" for i, body in enumerate(bodies[2:-1])],
+    *[f"<div class=\"middle_{i}\">\n{body}\n</div>" for i, body in enumerate(bodies[2:-1])],
     rf"""<div class="right">
     {right_body}
     </div>
@@ -105,21 +105,11 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
 def max_file_time(path: pathlib.Path):
     times = []
 
-    if path.match(".*"):  # This should ignore hidden directories such as .git/ not sure if this breaks css
-        return None
-
-    for subpath in path.iterdir():
-        if subpath.is_file():
-            times.append(subpath.stat().st_mtime)
-        elif subpath.is_dir():
-            SubdirMaxTime = max_file_time(subpath)
-            if SubdirMaxTime:
-                times.append(SubdirMaxTime)
-
-    if times:  # Handle empty directories
-        return max(times)
-    else:
-        return None
+    if not path.match(".*"):
+        if path.is_file():
+            times.append(path.stat().st_mtime)
+        elif path.is_dir() and (len(path.iterdir()) > 0):
+            times.append(max_file_time(path))
 
 
 def main(datadir):

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -102,8 +102,14 @@ def max_file_time(path: pathlib.Path):
         if subpath.is_file():
             times.append(subpath.stat().st_mtime)
         elif subpath.is_dir():
-            times.append(max_file_time(subpath))
-    return max(times)
+            SubdirMaxTime = max_file_time(subpath)
+            if SubdirMaxTime:
+                times.append(SubdirMaxTime)
+
+    if times:  # Handle empty directories
+        return max(times)
+    else:
+        return None
 
 
 def main(datadir):

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -21,12 +21,15 @@ def md_to_html(md: str):
     )
 
 
+def excludeHiddenDirs(path, subdirs):
+    return [p for p in subdirs if p.startswith(".")]
+
 def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.Path):
     if (datadir / "icons").exists():
         raise ValueError
     if (datadir / "stylesheets").exists():
         raise ValueError
-    shutil.copytree(datadir, tempdir, dirs_exist_ok=True)
+    shutil.copytree(datadir, tempdir, dirs_exist_ok=True, ignore=excludeHiddenDirs)
 
     md_file = tempdir / "poster.md"
     html_file = tempdir / "index.html"

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -101,6 +101,10 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
 
 def max_file_time(path: pathlib.Path):
     times = []
+
+    if path.match(".*"):  # This should ignore hidden directories such as .git/ not sure if this breaks css
+        return None
+
     for subpath in path.iterdir():
         if subpath.is_file():
             times.append(subpath.stat().st_mtime)

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -63,7 +63,7 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
     <div class="left">
     {left_body}
     </div>""", 
-    *[f"<div class=\"Middle_{i}\">\n{body}\n</div>" for i, body in enumerate(bodies[2:-1])],
+    *[f"<div class=\"middle_{i}\">\n{body}\n</div>" for i, body in enumerate(bodies[2:-1])],
     rf"""<div class="right">
     {right_body}
     </div>

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -41,7 +41,7 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
 
     bodies = [md_to_html(b) for b in bodies]
     banner = bodies[0]
-    left_body = bodies[1]  # Still capture left and right separately for backwards compatibility
+    left_body = bodies[1]# Still capture left and right seperatly for backwards compadibility
     right_body = bodies[-1]
     
     html_out = "\n".join([rf"""<!doctype html>
@@ -63,7 +63,7 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
     <div class="left">
     {left_body}
     </div>""", 
-    *[f"<div class=\"middle_{i}\">\n{body}\n</div>" for i, body in enumerate(bodies[2:-1])],
+    *[f"<div class=\"Middle_{i}\">\n{body}\n</div>" for i, body in enumerate(bodies[2:-1])],
     rf"""<div class="right">
     {right_body}
     </div>
@@ -105,11 +105,14 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
 def max_file_time(path: pathlib.Path):
     times = []
 
-    if not path.match(".*"):
-        if path.is_file():
-            times.append(path.stat().st_mtime)
-        elif path.is_dir() and (len(path.iterdir()) > 0):
-            times.append(max_file_time(path))
+    for subpath in path.iterdir():
+        if not subpath.match(".*"):
+            if subpath.is_file():
+                times.append(subpath.stat().st_mtime)
+            elif subpath.is_dir() and list(subpath.iterdir()):
+                times.append(max_file_time(subpath))
+
+    return max(times)
 
 
 def main(datadir):

--- a/mkposters/mkposter.py
+++ b/mkposters/mkposter.py
@@ -34,12 +34,14 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
 
     with md_file.open() as f:
         contents = f.read()
-    banner, left_body, right_body = contents.split("--split--")
+    bodies = contents.split("--split--")
 
-    banner = md_to_html(banner)
-    left_body = md_to_html(left_body)
-    right_body = md_to_html(right_body)
-    html_out = rf"""<!doctype html>
+    bodies = [md_to_html(b) for b in bodies]
+    banner = bodies[0]
+    left_body = bodies[1]# Still capture left and right seperatly for backwards compadibility
+    right_body = bodies[-1]
+    
+    html_out = "\n".join([rf"""<!doctype html>
     <html>
     <head>
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
@@ -57,14 +59,15 @@ def parse(datadir: pathlib.Path, tempdir: pathlib.Path, join_scss_file: pathlib.
     <div class="body md-typeset">
     <div class="left">
     {left_body}
-    </div>
-    <div class="right">
+    </div>""", 
+    *[f"<div class=\"Middle_{i}\">\n{body}\n</div>" for i, body in enumerate(bodies[2:-1])],
+    rf"""<div class="right">
     {right_body}
     </div>
     </div>
     </body>
     </html>
-    """  # noqa: E501
+    """])  # noqa: E501
 
     # check if post-install of dart-sass is needed
     if not (_here / "third_party" / "dart-sass" / "SASSBUILT.txt").exists():


### PR DESCRIPTION
Handle empty directories in the poster folder. 

Handle more than two colls. Also, name the first and second tags right and left for backward compatibility. This could be implemented inside the list comprehension to handle single-column posters but my poster is due this week :).

Ignore hidden directories in max_file_time. This ignores .git so I like it but it could go either way.